### PR TITLE
Check path exists before removing

### DIFF
--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -450,9 +450,12 @@ class Default(protocol.RSEProtocol):
 
         try:
             for path in paths:
-                ret = ctx.unlink(str(path))
-                if ret:
-                    return ret
+                if self.__gfal2_exist(path):
+                    ret = ctx.unlink(str(path))
+                    if ret:
+                        return ret
+                else:
+                    raise exception.SourceNotFound
             return ret
         except gfal2.GError as error:  # pylint: disable=no-member
             if error.code == errno.ENOENT or 'No such file' in str(error):

--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -450,7 +450,7 @@ class Default(protocol.RSEProtocol):
 
         try:
             for path in paths:
-                if self.__gfal2_exist(path):
+                if self.__gfal2_exist(path) == 0:
                     ret = ctx.unlink(str(path))
                     if ret:
                         return ret


### PR DESCRIPTION
Necessary becase a few CMS sites using gsiftp+hadoop have a broken
implementation where removing a nonexistent file does not produce the
correct error code, leading rucio to declare deletion-failed rather than
the expected source not found, which is considered a success.

I think we don't want this in the long term.